### PR TITLE
Patch back && Feat reset-password

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -85,11 +85,11 @@ class User extends Authenticatable
         return $this->hasOne(UserPatient::class, 'uuid', 'uuid');
     }
 
-    /**
-     * Relation avec les préférences
-     */
-    public function preference(): HasOne
-    {
-        return $this->hasOne(Preference::class, 'user_uuid', 'uuid');
-    }
+    // /**
+    //  * Relation avec les préférences
+    //  */
+    // public function preference(): HasOne
+    // {
+    //     return $this->hasOne(Preference::class, 'user_uuid', 'uuid');
+    // }
 }

--- a/api/app/Services/EmailService.php
+++ b/api/app/Services/EmailService.php
@@ -9,41 +9,59 @@ use Carbon\Carbon;
 
 class EmailService
 {
-  private const COMPANY_LOGO_URL = 'http://localhost:4200/assets/logo.png';
-  private const TOKEN_VALIDITY_HOURS = 24;
+    private const COMPANY_LOGO_URL = 'http://localhost:4200/assets/logo.png';
+    private const TOKEN_VALIDITY_HOURS = 24;
 
-  public function sendRegistrationEmail(array $user, string $token): void
-{
-    try {
-        $expirationDate = Carbon::now()->addHours(self::TOKEN_VALIDITY_HOURS)->format('d/m/Y H:i');
+    public function sendRegistrationEmail(array $user, string $token): void
+    {
+        try {
+            $expirationDate = Carbon::now()->addHours(self::TOKEN_VALIDITY_HOURS)->format('d/m/Y H:i');
 
-        Log::info('Sending registration email', [
-            'user_email' => $user['email'],
-            'token' => $token,
-            'validation_url' => "http://localhost:8000/api/auth/verify?token=". $token
-        ]);
+            Log::info('Sending registration email', [
+                'user_email' => $user['email'],
+                'token' => $token,
+                'validation_url' => "http://localhost:8000/api/auth/verify?token=". $token
+            ]);
 
-        Mail::send('emails.user_registration', [
-            'firstName' => $user['firstname'],
-            'lastName' => $user['lastname'],
-            'logoUrl' => self::COMPANY_LOGO_URL,
-          'validationUrl' => "http://localhost:8000/api/auth/verify?token=" . $token,
-            'expirationDate' => $expirationDate
-        ], function (Message $message) use ($user) {
-            $message->to($user['email'])
-                ->subject('Bienvenue sur MindCare - Vérification de votre email');
-        });
+            Mail::send('emails.user_registration', [
+                'firstName' => $user['firstname'],
+                'lastName' => $user['lastname'],
+                'logoUrl' => self::COMPANY_LOGO_URL,
+            'validationUrl' => "http://localhost:8000/api/auth/verify?token=" . $token,
+                'expirationDate' => $expirationDate
+            ], function (Message $message) use ($user) {
+                $message->to($user['email'])
+                    ->subject('Bienvenue sur MindCare - Vérification de votre email');
+            });
 
-        Log::info('Registration email sent successfully', [
-            'user_email' => $user['email']
-        ]);
-    } catch (\Exception $e) {
-        Log::error('Failed to send registration email', [
-            'error' => $e->getMessage(),
-            'trace' => $e->getTraceAsString(),
-            'user' => $user['email']
-        ]);
-        throw $e;
+            Log::info('Registration email sent successfully', [
+                'user_email' => $user['email']
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to send registration email', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'user' => $user['email']
+            ]);
+            throw $e;
+        }
     }
-}
+
+    public function sendPasswordResetEmail(array $userData, string $token)
+    {
+        $expirationDate = now()->addHours(24)->format('d/m/Y H:i');
+        $resetUrl = env('FRONTEND_URL', 'http://localhost:4200') . '/auth/reset-password?token=' . $token;
+        $logoUrl = env('APP_URL', 'http://localhost:8000') . '/images/logo.png';
+
+        Mail::send('emails.password_reset', [
+            'firstName' => $userData['firstname'],
+            'lastName' => $userData['lastname'],
+            'resetUrl' => $resetUrl,
+            'expirationDate' => $expirationDate,
+            'logoUrl' => $logoUrl
+        ], function ($message) use ($userData) {
+            $message->to($userData['email'])
+                ->subject('Réinitialisation de votre mot de passe MindCare');
+        });
+    }
 }

--- a/api/resources/views/emails/password_reset.blade.php
+++ b/api/resources/views/emails/password_reset.blade.php
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Réinitialisation de votre mot de passe - MindCare</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+            background-color: #f9f9f9;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #ffffff;
+            border-radius: 5px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            text-align: center;
+            padding: 20px 0;
+            border-bottom: 1px solid #eaeaea;
+        }
+        .logo {
+            max-width: 180px;
+            height: auto;
+        }
+        .content {
+            padding: 30px 20px;
+        }
+        h1 {
+            color: #3a7bd5;
+            font-size: 24px;
+            margin-top: 0;
+        }
+        .button {
+            display: inline-block;
+            background-color: #3a7bd5;
+            color: #ffffff !important;
+            text-decoration: none;
+            padding: 12px 25px;
+            border-radius: 4px;
+            margin: 20px 0;
+            font-weight: bold;
+        }
+        .expiration {
+            font-size: 14px;
+            color: #777;
+            font-style: italic;
+            margin-top: 30px;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px;
+            font-size: 12px;
+            color: #999;
+            border-top: 1px solid #eaeaea;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <img src="{{ $logoUrl }}" alt="MindCare Logo" class="logo">
+        </div>
+        <div class="content">
+            <h1>Bonjour {{ $firstName }} {{ $lastName }},</h1>
+            <p>Vous avez récemment demandé la réinitialisation de votre mot de passe sur MindCare.</p>
+            <p>Pour définir un nouveau mot de passe, veuillez cliquer sur le bouton ci-dessous :</p>
+            <div style="text-align: center;">
+                <a href="{{ $resetUrl }}" class="button">Réinitialiser mon mot de passe</a>
+            </div>
+            <p>Si le bouton ne fonctionne pas, vous pouvez également copier et coller le lien suivant dans votre navigateur :</p>
+            <p style="word-break: break-all;">{{ $resetUrl }}</p>
+            <p class="expiration">Ce lien est valable jusqu'au {{ $expirationDate }}.</p>
+            <p>Si vous n'avez pas demandé cette réinitialisation, vous pouvez ignorer cet email en toute sécurité.</p>
+        </div>
+        <div class="footer">
+            <p>Cet email a été envoyé automatiquement, merci de ne pas y répondre.</p>
+            <p>&copy; {{ date('Y') }} MindCare. Tous droits réservés.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\ProfileController;
@@ -17,7 +16,10 @@ Route::prefix('auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
     Route::post('/register/patient', [AuthController::class, 'registerPatient']);
     Route::post('/register/pro', [AuthController::class, 'registerPro']);
-    Route::get('/verify/{token}', [AuthController::class, 'verify']);
+    Route::get('/verify', [AuthController::class, 'verify']);
+
+    Route::post('/forgot-password', [AuthController::class, 'forgotPassword']);
+    Route::post('/reset-password', [AuthController::class, 'resetPassword']);
 
     // Routes protégées par authentification
     Route::middleware('auth:sanctum')->group(function () {
@@ -27,7 +29,7 @@ Route::prefix('auth')->group(function () {
 });
 
 // Route de déchiffrement (protégée par authentification)
-Route::middleware('auth:sanctum')->post('/decrypt', [DecryptionController::class, 'decrypt']);
+// Route::middleware('auth:sanctum')->post('/decrypt', [DecryptionController::class, 'decrypt']);
 
 // Routes de profil protégées par authentification
 Route::middleware('auth:sanctum')->prefix('profile')->group(function () {


### PR DESCRIPTION
Le merge du dashboard d'Abou avait modifié 8 fichiers du back, le rendant obsolète.
J'ai corrigé les erreurs qui sont apparues (merci de faire un pull de main et de tester de votre côté pour faire remonter toute erreur, quelle qu'elle soit) et j'ai implémenté le système de mot de passe oublié.

Lorsqu’un utilisateur cliquera sur "mot de passe oublié", il recevra un mail avec un lien (vers le front) contenant un token pour modifier son mot de passe.
NB : La route pour modifier le mot de passe est différente de celle pour l’oubli du mot de passe.
Il faudra envoyer dans le payload du /api/auth/reset-password/:

{
   "token": "",
   "password": "",
   "password_confirmation": ""
}